### PR TITLE
Add PDF privacy policy form with jsPDF

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Privacy Policy Generator
 
-This repository contains a small web application that generates a Privacy and Data Protection Policy based on a template. The template is stored in `template.txt` and uses placeholders enclosed in square brackets (e.g. `[COMPANY]`, `[CUSTOMER NAME]` and `[NAME SYSTEM]`). When running the app, you provide values for these placeholders via a form. The application replaces the placeholders with your values and outputs the completed policy, which you can then download as a plain text file.
+This repository contains a small web application that builds a Privacy and Data Protection Policy based on answers you provide in a form. The policy text is stored in `policy-template.txt` and uses placeholders enclosed in square brackets (e.g. `[COMPANY_NAME]`). When running the app, you provide values for these placeholders via a multi-section form. The application replaces the placeholders with your values and outputs the completed policy, which automatically downloads as a PDF using [jsPDF](https://github.com/parallax/jsPDF).
 
 ## Running locally
 
@@ -11,22 +11,8 @@ No build step or installation is required. Simply open `index.html` in a web bro
 open privacypolicy/index.html
 ```
 
-Fill out the form and click **Generate**. The completed policy will appear on the page along with a download link.
-
-## Placeholders
-
-The template contains a number of placeholders which you can replace:
-
-| Placeholder      | Description                               |
-|------------------|-------------------------------------------|
-| `COMPANY`        | Your company name                         |
-| `CUSTOMER NAME`  | Name of the customer or legal entity      |
-| `NAME SYSTEM`    | Name of the internal system or platform   |
-| `_____`          | CEO name or signatory                     |
-| `_______`        | Additional field for a miscellaneous value |
-
-If a placeholder is left blank in the form, it will remain unchanged in the generated policy.
+Fill out the form and click **Generate**. The completed policy will appear on the page and a PDF will be downloaded to your machine.
 
 ## Modifying the template
 
-The privacy policy text is stored in `template.txt`. You can edit this file to tailor the policy to your needs. Make sure to keep the placeholder tokens (such as `[COMPANY]`) intact so the generator can replace them correctly.
+The privacy policy text is stored in `policy-template.txt`. You can edit this file to tailor the policy to your needs. Make sure to keep the placeholder tokens (such as `[COMPANY_NAME]`) intact so the generator can replace them correctly.

--- a/index.html
+++ b/index.html
@@ -17,12 +17,26 @@
         text-align: center;
       }
       main {
-        max-width: 800px;
+        max-width: 900px;
         margin: 2rem auto;
         background: #fff;
         padding: 2rem;
         border-radius: 8px;
         box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1);
+      }
+      section {
+        margin-top: 1.5rem;
+        border-top: 1px solid #eee;
+        padding-top: 1rem;
+      }
+      section:first-of-type {
+        border-top: none;
+        padding-top: 0;
+      }
+      h2 {
+        margin-bottom: 0.5rem;
+        font-size: 1.2rem;
+        color: #333;
       }
       label {
         font-weight: bold;
@@ -62,18 +76,6 @@
         overflow-y: auto;
         display: none;
       }
-      a.download-link {
-        display: none;
-        margin-top: 1rem;
-        background: #28a745;
-        color: #fff;
-        padding: 0.5rem 1rem;
-        border-radius: 4px;
-        text-decoration: none;
-      }
-      a.download-link:hover {
-        background: #218838;
-      }
     </style>
   </head>
   <body>
@@ -82,212 +84,169 @@
     </header>
     <main>
       <p>
-        Use this form to generate a privacy policy based on our template. Provide
-        values for each placeholder and click <strong>Generate</strong>. The
-        completed policy will display below and can be downloaded as a text file.
+        Use this form to generate a privacy policy based on your answers. Fill out
+        the sections below and click <strong>Generate</strong>. The completed policy will
+        display on the page and download as a PDF.
       </p>
       <form id="policyForm">
-        <label for="companyName">Company Name</label>
-        <input type="text" id="companyName" name="companyName" required />
+        <section>
+          <h2>Company Info</h2>
+          <label for="companyName">What is your company name?</label>
+          <input type="text" id="companyName" name="companyName" required />
+          <label for="companyLocation">Where is your company based?</label>
+          <input type="text" id="companyLocation" name="companyLocation" />
+          <label for="companyWebsite">Company website?</label>
+          <input type="text" id="companyWebsite" name="companyWebsite" />
+          <label for="ceoName">CEO name?</label>
+          <input type="text" id="ceoName" name="ceoName" />
+        </section>
 
-        <label for="customerName">Customer Name</label>
-        <input type="text" id="customerName" name="customerName" required />
+        <section>
+          <h2>DPO & Contacts</h2>
+          <label for="dpoName">Do you have a Data Protection Officer? If so, name?</label>
+          <input type="text" id="dpoName" name="dpoName" />
+          <label for="dpoEmail">DPO email?</label>
+          <input type="text" id="dpoEmail" name="dpoEmail" />
+          <label for="dpoLocation">DPO location?</label>
+          <input type="text" id="dpoLocation" name="dpoLocation" />
+          <label for="privacyEmail">Privacy contact email?</label>
+          <input type="text" id="privacyEmail" name="privacyEmail" />
+          <label for="ukRep">Data Protection Representative in UK?</label>
+          <input type="text" id="ukRep" name="ukRep" />
+        </section>
 
-        <label for="systemName">Internal System Name</label>
-        <input type="text" id="systemName" name="systemName" required />
+        <section>
+          <h2>Types of Data</h2>
+          <label for="dataSubjects">Who are your data subjects?</label>
+          <input type="text" id="dataSubjects" name="dataSubjects" />
+          <label for="dataCategories">What categories of personal data do you process?</label>
+          <input type="text" id="dataCategories" name="dataCategories" />
+        </section>
 
-        <label for="ceoName">CEO Name (Signature)</label>
-        <input type="text" id="ceoName" name="ceoName" />
+        <section>
+          <h2>Legal Basis</h2>
+          <label for="legalBasis">What is your legal basis for processing data?</label>
+          <input type="text" id="legalBasis" name="legalBasis" />
+        </section>
 
-        <label for="extra">Additional Placeholder</label>
-        <input type="text" id="extra" name="extra" />
+        <section>
+          <h2>Retention/Disposal</h2>
+          <label for="retentionPeriod">How long do you retain personal data?</label>
+          <input type="text" id="retentionPeriod" name="retentionPeriod" />
+          <label for="disposalMethod">How do you dispose of data?</label>
+          <input type="text" id="disposalMethod" name="disposalMethod" />
+        </section>
+
+        <section>
+          <h2>Data Transfers</h2>
+          <label for="transferOutsideEU">Do you transfer data outside the EU/EEA?</label>
+          <input type="text" id="transferOutsideEU" name="transferOutsideEU" />
+          <label for="transferSafeguards">What safeguards?</label>
+          <input type="text" id="transferSafeguards" name="transferSafeguards" />
+        </section>
+
+        <section>
+          <h2>Subprocessors/Vendors</h2>
+          <label for="useVendors">Do you use vendors/subprocessors?</label>
+          <input type="text" id="useVendors" name="useVendors" />
+          <label for="vendorManagement">How do you select and monitor them?</label>
+          <input type="text" id="vendorManagement" name="vendorManagement" />
+        </section>
+
+        <section>
+          <h2>Rights Requests</h2>
+          <label for="rightsExercise">How can people exercise their data rights?</label>
+          <input type="text" id="rightsExercise" name="rightsExercise" />
+        </section>
+
+        <section>
+          <h2>Supervisory Authority</h2>
+          <label for="complaintEscalation">How can people escalate complaints?</label>
+          <input type="text" id="complaintEscalation" name="complaintEscalation" />
+          <label for="supervisoryAuthority">Which authority?</label>
+          <input type="text" id="supervisoryAuthority" name="supervisoryAuthority" />
+        </section>
+
+        <section>
+          <h2>IT Systems</h2>
+          <label for="itSystems">What are the main systems/repositories for personal data?</label>
+          <input type="text" id="itSystems" name="itSystems" />
+        </section>
+
+        <section>
+          <h2>Versioning</h2>
+          <label for="policyOwner">Who is responsible for the policy?</label>
+          <input type="text" id="policyOwner" name="policyOwner" />
+          <label for="approvalDate">Approval date?</label>
+          <input type="text" id="approvalDate" name="approvalDate" />
+          <label for="version">Version?</label>
+          <input type="text" id="version" name="version" />
+        </section>
 
         <button type="submit">Generate</button>
       </form>
       <div id="result"></div>
-      <a id="downloadLink" class="download-link" href="#">Download Policy</a>
     </main>
 
-    <!-- Template stored inside a script tag so it can be read by JavaScript. -->
-    <script id="policy-template" type="text/plain">
- PRIVACY AND DATA PROTECTION POLICY PRIVACY AND DATA PROTECTION POLICY[COMPANY][COMPANY]
- PRIVACY AND DATA PROTECTION POLICY
- PRIVACY AND DATA PROTECTION POLICY
-[COMPANY]
-[COMPANY]
-Index
-1.Introduction3
-2.Responsibilities and roles under the Privacy and Data Protection Regulations4
-3.Data protection principles5
-4.Data Subjects’ rights6
-5.Security of data7
-6.Disclosure of data7
-7.Retention and disposal of data7
-8.Data transfers8
-9.Assessments9
-10.Information asset register/data inventory10
-Introduction
-Privacy and Data Protection Program
-[CUSTOMER NAME] and other affiliates as created or acquired from time to time (collectively “[CUSTOMER NAME]”) is subject to privacy and data protection regulations worldwide and the organization is committed to complying with applicable portions of those regulations (the “Privacy and Data Protection Regulations”).  This program document outlines [CUSTOMER NAME]’ key responsibilities to comply with Privacy and Data Protection Regulations as they apply to the processing of Personal Data.
-[CUSTOMER NAME] is established in the European Union through its subsidiary, [CUSTOMER NAME] and complies with the EU General Data Protection Regulation (EU GDPR) via its third party Data Protection Officer in The Netherlands.  [CUSTOMER NAME] also maintains a third party Data Protection Representative in the United Kingdom pursuant to UK GDPR.  All other global privacy and data protection compliance is managed through [CUSTOMER NAME]’ Operations team.  [CUSTOMER NAME] aims to comply with privacy and data protection standards that provide for the most protection of Data Subjects’ rights.
-Compliance with the Privacy and Data Protection Regulations is described by this program document and addressed in related policies and procedures set forth in Exhibit A. The Privacy and Data Protection Regulations and this policy apply to all of [CUSTOMER NAME]’ Personal Data processing functions, including those performed on customers’, clients’, employees’, suppliers’ and partners’ Personal Data, and any other Personal Data that [CUSTOMER NAME] Processes from any source.  [CUSTOMER NAME] has implemented engineering and communications procedures/worksheets that require a review of Privacy by Design principles prior to implementation or development of processes that involve personal data.
-This program applies to all [CUSTOMER NAME] employees and outsourced personnel. Any breach of the Privacy and Data Protection Regulations will be dealt with under [CUSTOMER NAME] disciplinary policy and may also be a criminal offence, in which case the matter will be reported as soon as possible to the appropriate authorities. Partners and any third parties working with or for [CUSTOMER NAME], and who have or may have access to Personal Data, are expected to comply with all contractual and applicable regulatory obligations. No Third Party may access Personal Data held by [CUSTOMER NAME] without having first agreed to confidentiality language set forth in the applicable agreement, which imposes on the third-party obligations no less onerous than those to which [CUSTOMER NAME] is committed, and which gives [CUSTOMER NAME] the right to audit compliance with the agreement.
-[CUSTOMER NAME] engages with consultants to assist with periodic audits of the program.  In addition, it utilizes consultants and industry resources to prepare for changes to Privacy and Data Protection Regulations.
-Definitions
-Definitions vary by Privacy and Data Protection Regulation.  The most common definitions are included below:
-Controller - determines the purpose and means of processing.  A Controller may be referred to as a business owner, business operator or other designation depending on the applicable Privacy and Data Protection Regulation.
-Data Subject – any living individual who is the subject of Personal Data Processed by or on behalf of [CUSTOMER NAME].  
-Personal Data – any information that is linked or reasonably linked to an identified or identifiable Data Subject; an identifiable natural person is one who can be identified, directly or indirectly, in particular by reference to an identifier such as a name, an identification number, location data, an online identifier or to one or more factors specific to the physical, physiological, genetic, mental, economic, cultural or social identity of that natural person.  California considers the above information as it relates to a “household” to also be Personal Data.
-Processing/Process/Processed/Processes – any operation or set of operations which is performed on Personal Data or on sets of Personal Data, whether or not by automated means, such as collection, recording, organization, structuring, storage, adaptation or alteration, retrieval, consultation, use, disclosure by transmission, dissemination or otherwise making available, alignment or combination, restriction, erasure or destruction. 
-Processor – conducts the processing of Personal Data on behalf, or at the direction, of the Controller.  A Processor may be referred to as a service provider, contractor or other designation depending on the applicable Privacy and Data Protection Regulation.
-Third Party – a natural or legal person, public authority, agency or body other than the Data Subject, Controller, Processor and persons who, under the direct authority of the Controller or Processor, are authorized to Process Personal Data.  
-Responsibilities and roles under the Privacy and Data Protection Regulations
-[CUSTOMER NAME] manages Privacy and Data Protection Regulation compliance through its Operations team. [CUSTOMER NAME] has assigned the role of EU Data Protection Officer to DPO Consultancy located in the Netherlands and UK Data Protection Representative to DPO Consultancy located in the UK.  Under EU GDPR and UK GDPR, there are no employees of [CUSTOMER NAME] with the required “independence” to act as Data Protection Officer under those regulations.  Operations assists the EU Data Protection Officer and UK Data Protection Representative in fulfilling their responsibilities set forth under the Privacy and Data Protection Regulations.
-Operations is responsible for overall management of the Privacy and Data Protection Program and maintains this program document as well as conducts periodic meetings with Senior Management regarding the program, including results of any audits, notification of issues, and notification of new Privacy and Data Protection Regulations or changes to existing Privacy and Data Protection Regulations.  As needed, Operations partners with third parties, such as the EU Data Protection Officer and/or UK Data Protection Representative, to communicate with team members and third parties.
-Operations is responsible for maintaining the register of processing (Data Processing Map) in the light of any changes to [CUSTOMER NAME]’ activities (as determined by changes to data processing and management review) and to any additional requirements identified by means of Data Processing Impact Assessments (DPIAs). Relevant Operations personnel and the EU Data Protection Officer review the Data Processing Map when any changes are made and advise on potential risks.  The Data Processing Map and any DPIAs are made available to government authorities pursuant to proper request.
-Operations maintains all privacy and data protection documentation, including internal and user-facing policies, which are updated as needed.  Operations conducts research and tracking of legislation and manages team member training.
-All employees are accountable for the management of Personal Data within [CUSTOMER NAME] and for ensuring that compliance with data protection legislation and good practice can be demonstrated. Employees competence requirements are set forth in the Privacy and Data Protection Competence Requirements.  Employee job descriptions include requirements set forth in the Personal Data Protection Job Description Responsibilities document.  This accountability includes:
-implementation of the Privacy and Data Protection Regulation program; and 
-security and risk management in relation to compliance with the program via adherence to [CUSTOMER NAME]’ Information Security Policy.
-Compliance with data protection legislation is the responsibility of all [CUSTOMER NAME] employees  who Process Personal Data and/or work with third parties that Process Personal Data on [CUSTOMER NAME]’ behalf. 
-[CUSTOMER NAME] employees are responsible for ensuring that any Personal Data about them and supplied by them to [CUSTOMER NAME] is accurate and up-to-date.  Employees seeking clarification on any aspect of data protection compliance related to their own Personal Data or that of third parties can contact: EU - eudpo@[CUSTOMER NAME].com, UK - ukdpr@[CUSTOMER NAME].com, Other - dpo@[CUSTOMER NAME].com.  
-Employees are trained on privacy and data protection requirements in relation to their specific roles. All training is managed by Operations and provided via third party training platform or ad hoc training by the Operations team, the EU DPO, or the UK DPR, as applicable.  The training schedule is set forth in the Privacy and Data Protection Training Matrix (see Tab 2).
-Any Processor processing Personal Data with or on behalf of [CUSTOMER NAME] is required pursuant to the terms of specific contracts to comply with Privacy and Data Protection Regulation requirements to the same standard and level as [CUSTOMER NAME] itself.
-[CUSTOMER NAME] does not provide online service to anyone under the age of majority (which ranges from 13-20 years old depending on jurisdiction and other age ranges elsewhere).  Users must have reached the minimum age of consent in their jurisdiction prior to using our service per the Privacy Policy and Terms of Service. 
-Data protection principles
-All processing of Personal Data must be conducted in accordance with the data protection principles as set out in Privacy and Data Protection Regulations.  For purposes of uniformity in the program, the b[... ELLIPSIZATION ...]cedures set forth in the Information Security Policy will apply in all cases.
-Personal Data must be disposed of securely in accordance with the Privacy and Data Protection Regulations and in accordance with the Information Security Policy.
-Data transfers
-[CUSTOMER NAME] treats all exports of data from within the Data Subject’s home country to other countries (or regions, i.e., with respect to EU GDPR) as unlawful unless there is an appropriate “level of protection for the fundamental rights of the Data Subjects.”  In all cases, [CUSTOMER NAME] will enter into appropriate contractual terms regarding the transfer (Data Processing Agreement), covering a Processor’s obligations as well as any of its sub-processors.  Third parties are assessed at the beginning of the relationship, upon any changes to the relationship, and every one to three years during the relationship pursuant to [CUSTOMER NAME]’ Vendor Management Policy and Procedures.  The following additional safeguards or exceptions may also apply depending on the origin and destination of the Personal Data:
-An adequacy decision
-Many countries maintain lists of other countries that adhere to adequate information and security protocols.  For example, countries that are members of the European Economic Area (EEA) but not of the EU are accepted as having met the conditions for an adequacy decision related to Personal Data derived from those countries’ residents.  
-Binding corporate rules
-Parties may adopt approved binding corporate rules for the transfer of data outside a Data Subject’s home country. In the EU, this requires submission to the relevant supervisory authority for approval of the rules that [CUSTOMER NAME] is seeking to rely upon.  
-Model contract clauses
-[CUSTOMER NAME] have adopted approved model contract clauses for the transfer of data outside of the EEA in connection with their Joint Controller arrangement.  These clauses may be provided in conjunction with a Data Processing Agreement and are updated as required by changes in law, regulation, or guidance.
-Exceptions
-In the absence of an adequacy decision, binding corporate rules, and/or model contract clauses, a transfer of Personal Data to a third country or international organization shall only take place on one of the following conditions:
-the Data Subject has explicitly consented to the proposed transfer, after having been informed of the possible risks of such transfers for the Data Subject due to the absence of an adequacy decision and appropriate safeguards;
-the transfer is necessary for the performance of a contract between the Data Subject and the Controller or the implementation of pre-contractual measures taken at the Data Subject's request;
-the transfer is necessary for the conclusion or performance of a contract concluded in the interest of the Data Subject between the Controller and another natural or legal person;
-the transfer is necessary for important reasons of public interest;
-the transfer is necessary for the establishment, exercise or defense of legal claims; and/or
-the transfer is necessary in order to protect the vital interests of the Data Subject or of other persons, where the Data Subject is physically or legally incapable of giving consent.
-In all cases, a Transfer Impact Assessment will be completed (see below).
-Assessments
-Data Protection Impact Assessments
-[CUSTOMER NAME] conducts data protection impact assessments (DPIAs) in relation to the processing of Personal Data by [CUSTOMER NAME] that potentially poses a high risk to the rights and freedoms to Data Subjects. [CUSTOMER NAME] DPIA template follows EU requirements and guidelines.  [CUSTOMER NAME] uses a template provided by its EU Data Protection Officer.  Where, as a result of a DPIA, [CUSTOMER NAME] chooses to commence processing of Personal Data that could cause damage and/or distress to the Data Subjects, the decision as to whether [CUSTOMER NAME] may proceed must be escalated for review to the Chief Operating Officer and the EU Data Protection Officer/UK Data Protection Representative.  The EU Data Protection Officer/UK Data Protection Representative shall, if there are significant concerns either as to the potential damage or distress or the quantity of data concerned, escalate the matter to the applicable supervisory authority.
-DPIA are updated at least every three (3) years and more often if there is a material change in the processing activity.
-Appropriate controls will be selected from Annex A of ISO 27001 or similar security standards and applied to reduce the level of risk associated with processing individual data to an acceptable level, by reference to the requirements of the Privacy and Data Protection Regulations.  Mitigating measures are communicated by Operations to the business owner of the processing activity, who is responsible for implementation of any necessary changes to the process.  The applicable DPIA is updated once the additional controls are in place.
-DPIAs are maintained by Operations in both the Shared Drive and saved to the appropriate Processing Activity record in [NAME SYSTEM].
-Privacy Impact Assessment 
-[CUSTOMER NAME] conducts Privacy Impact Assessments (PIAs) as required by various Privacy and Data Protection Regulations related to the processing of personal data.  PIAs are conducted on all new processing activities that do not warrant a DPIA. Where a DPIA is conducted for a processing activity, a PIA will not be conducted.  PIAs are conducted and maintained by Operations within [NAME SYSTEM] using the [NAME SYSTEM] template and saved to the appropriate Processing Activity record in [NAME SYSTEM].
-Transfer Impact Assessments
-[CUSTOMER NAME] conducts Transfer Impact Assessments (TIAs) as set forth by the EU for transfers of data across borders (unless approved within certain regions, i.e., EEA).  TIAs are not completed for transfers of European Personal Data to jurisdictions that have obtained Adequacy status (however, appropriate contractual measures are still required).  [CUSTOMER NAME] utilizes a TIA template provided by its EU Data Protection Officer, who reviews and provides advice in each instance.  Where possible, risks are mitigated contractually and by implementing supplementary measures according to the requirements of the Privacy and Data Protection Regulations and the Supervisory Authorities' guidelines.  Unmitigated risks are provided to the Chief Operating Officer for review and acceptance or denial and completed TIAs are maintained by Operations in both the Shared Drive and saved to the appropriate Asset record in [NAME SYSTEM].
-LIA
-[CUSTOMER NAME] conducts Legitimate Interest Assessments (LIAs) as required by various Privacy and Data Protection Regulations related to the processing of personal data that relies on the legitimate interest legal processing basis.  LIAs related to European Personal Data are reviewed by [CUSTOMER NAME]’ EU Data Protection Officer. Unmitigated risks are provided to the Chief Operating Officer for review and acceptance or denial. LIAs are conducted and maintained by Operations within [NAME SYSTEM] using the [NAME SYSTEM] template and saved to the appropriate Processing Activity record in [NAME SYSTEM].
-Information asset register/data inventory
-[CUSTOMER NAME] has established a data inventory and data flow process as part of its approach to address risks and opportunities throughout its privacy and data protection compliance program. [CUSTOMER NAME]’ data inventory determines:
-business processes that use Personal Data;
-source of Personal Data; 
-volume of Data Subjects;
-description of each item of Personal Data;
-processing activity;
-maintains the inventory of data categories of Personal Data it Processes; 
-documents the purpose(s) for which each category of Personal Data is used;
-recipients, and potential recipients, of the Personal Data;
-the role of [CUSTOMER NAME] throughout the data flow;
-key systems and repositories;
-any data transfers; and
-all retention and disposal requirements. 
-[CUSTOMER NAME] reviews and updates the data inventory on an ongoing basis to ensure it remains accurate related to any changes in the entities processing activities.
-Document Owner and Approval
-Operations is the owner of this document and is responsible for ensuring that this policy document is reviewed periodically and with senior management input, as applicable. 
-This policy was approved by the senior management team on the date set forth below and is issued on a version-controlled basis.
-, CEO _____________________
-Date ___________________
-Change History Record
-Issue
-Description of Change
-Approval
-Date of Issue
-1
-Initial issue
-[_____] 2022
-Exhibit A - Related Processes and Procedures
-Information Security Policy
-Data Governance Program (for now, refer to the Personal Data Retention and Disposal Schedule) 
-Personal Data Erasure Exceptions 
-Privacy and Data Protection Competence Record and Training Matrix
-Incident Response Policy and Procedure
-Vendor Management Policy and Procedure
-Data Processing Impact Assessments - also maintained in [NAME SYSTEM] Processing Activity records
-Transfer Impact Assessments - also maintained in [NAME SYSTEM] Asset records
-Privacy Impact Assessments - maintained in [NAME SYSTEM] Processing Activity records
-Legitimate Interest Assessments - maintained in [NAME SYSTEM] Processing Activity records
-Data Processing Map (GDPR Art. 30 Register) - maintained in [NAME SYSTEM] Data Mapping module
-Cookie management procedure - scripts and consent records maintained in [NAME SYSTEM] Consent module and procedure maintained by Operations Engineering
-DSAR procedure - maintained by Community Support
-Marketing opt-ins/out information - maintained by Marketing
-Privacy and Data Protection Audits
-[CUSTOMER NAME].com Privacy Policy
-California Privacy Notice
-[CUSTOMER NAME] App Privacy Notice
-[CUSTOMER NAME].com Cookie and Internet Advertising Policy
-Employee Privacy Policy
-Personal Data Protection Job Description Responsibilities
-[_______]
-    </script>
-
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
     <script>
-      // Read template from the script tag
-      const templateText = document.getElementById('policy-template').textContent;
+      async function loadTemplate() {
+        const response = await fetch('policy-template.txt');
+        return await response.text();
+      }
 
-      /**
-       * Replace placeholders in the template with user-provided values.
-       * Placeholders are enclosed in square brackets, e.g. [COMPANY].
-       * @param {string} text The template
-       * @param {Object} replacements Key-value pairs mapping placeholder names to values
-       */
       function replacePlaceholders(text, replacements) {
         let output = text;
         for (const key in replacements) {
-          const value = replacements[key];
-          if (!value) continue;
           const regex = new RegExp(`\\[${key}\\]`, 'g');
-          output = output.replace(regex, value);
+          output = output.replace(regex, replacements[key] || '');
         }
         return output;
       }
 
-      // Handle form submission
-      document.getElementById('policyForm').addEventListener('submit', function (e) {
+      document.getElementById('policyForm').addEventListener('submit', async (e) => {
         e.preventDefault();
-        const companyName = document.getElementById('companyName').value.trim();
-        const customerName = document.getElementById('customerName').value.trim();
-        const systemName = document.getElementById('systemName').value.trim();
-        const ceoName = document.getElementById('ceoName').value.trim();
-        const extra = document.getElementById('extra').value.trim();
-
+        const formData = new FormData(e.target);
         const replacements = {
-          'COMPANY': companyName,
-          'CUSTOMER NAME': customerName,
-          'NAME SYSTEM': systemName,
-          '_____': ceoName,
-          '_______': extra,
+          'COMPANY_NAME': formData.get('companyName').trim(),
+          'COMPANY_LOCATION': formData.get('companyLocation').trim(),
+          'COMPANY_WEBSITE': formData.get('companyWebsite').trim(),
+          'CEO_NAME': formData.get('ceoName').trim(),
+          'DPO_NAME': formData.get('dpoName').trim(),
+          'DPO_EMAIL': formData.get('dpoEmail').trim(),
+          'DPO_LOCATION': formData.get('dpoLocation').trim(),
+          'PRIVACY_EMAIL': formData.get('privacyEmail').trim(),
+          'UK_REP': formData.get('ukRep').trim(),
+          'DATA_SUBJECTS': formData.get('dataSubjects').trim(),
+          'DATA_CATEGORIES': formData.get('dataCategories').trim(),
+          'LEGAL_BASIS': formData.get('legalBasis').trim(),
+          'RETENTION_PERIOD': formData.get('retentionPeriod').trim(),
+          'DISPOSAL_METHOD': formData.get('disposalMethod').trim(),
+          'TRANSFER_OUTSIDE_EU': formData.get('transferOutsideEU').trim(),
+          'TRANSFER_GUARDS': formData.get('transferSafeguards').trim(),
+          'USE_VENDORS': formData.get('useVendors').trim(),
+          'VENDOR_MANAGEMENT': formData.get('vendorManagement').trim(),
+          'RIGHTS_EXERCISE': formData.get('rightsExercise').trim(),
+          'COMPLAINT_ESCALATION': formData.get('complaintEscalation').trim(),
+          'SUPERVISORY_AUTHORITY': formData.get('supervisoryAuthority').trim(),
+          'IT_SYSTEMS': formData.get('itSystems').trim(),
+          'POLICY_OWNER': formData.get('policyOwner').trim(),
+          'APPROVAL_DATE': formData.get('approvalDate').trim(),
+          'VERSION': formData.get('version').trim(),
         };
-        const filled = replacePlaceholders(templateText, replacements);
+
+        const template = await loadTemplate();
+        const filled = replacePlaceholders(template, replacements);
 
         const resultDiv = document.getElementById('result');
         resultDiv.textContent = filled;
         resultDiv.style.display = 'block';
 
-        const blob = new Blob([filled], { type: 'text/plain' });
-        const url = URL.createObjectURL(blob);
-        const downloadLink = document.getElementById('downloadLink');
-        downloadLink.href = url;
-        downloadLink.download = 'privacy_policy.txt';
-        downloadLink.style.display = 'inline-block';
+        const { jsPDF } = window.jspdf;
+        const doc = new jsPDF();
+        const lines = doc.splitTextToSize(filled, 180);
+        doc.text(lines, 10, 10);
+        doc.save('privacy_policy.pdf');
       });
     </script>
   </body>

--- a/policy-template.txt
+++ b/policy-template.txt
@@ -1,0 +1,46 @@
+Privacy and Data Protection Policy
+
+Company Information
+Company Name: [COMPANY_NAME]
+Company Location: [COMPANY_LOCATION]
+Company Website: [COMPANY_WEBSITE]
+CEO: [CEO_NAME]
+
+Data Protection Officer and Contacts
+DPO: [DPO_NAME] ([DPO_EMAIL]) - [DPO_LOCATION]
+Privacy Contact Email: [PRIVACY_EMAIL]
+UK Representative: [UK_REP]
+
+Types of Data
+Data Subjects: [DATA_SUBJECTS]
+Categories of Personal Data: [DATA_CATEGORIES]
+
+Legal Basis
+Legal Basis for Processing: [LEGAL_BASIS]
+
+Retention and Disposal
+Retention Period: [RETENTION_PERIOD]
+Disposal Method: [DISPOSAL_METHOD]
+
+Data Transfers
+Transfers outside EU/EEA: [TRANSFER_OUTSIDE_EU]
+Safeguards: [TRANSFER_GUARDS]
+
+Subprocessors and Vendors
+Use Vendors: [USE_VENDORS]
+Vendor Management: [VENDOR_MANAGEMENT]
+
+Rights Requests
+How to Exercise Rights: [RIGHTS_EXERCISE]
+
+Supervisory Authority
+Complaint Escalation: [COMPLAINT_ESCALATION]
+Supervisory Authority: [SUPERVISORY_AUTHORITY]
+
+IT Systems
+Main Systems: [IT_SYSTEMS]
+
+Versioning
+Policy Owner: [POLICY_OWNER]
+Approval Date: [APPROVAL_DATE]
+Version: [VERSION]


### PR DESCRIPTION
## Summary
- Replace web form with multi-section questionnaire for company details, contacts, data handling, and versioning
- Load new policy template and generate filled PDF via jsPDF
- Update README with usage instructions

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_b_688cdcae2f008332bddc3e56630422c6